### PR TITLE
If font loading fails use default font

### DIFF
--- a/packages/troika-three-text/package.json
+++ b/packages/troika-three-text/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metrica-sports/troika-three-text",
   "description": "SDF-based text rendering for Three.js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Metrica Sports",
     "email": "info@metrica-sports.com"

--- a/packages/troika-three-text/src/FontResolver.js
+++ b/packages/troika-three-text/src/FontResolver.js
@@ -50,6 +50,7 @@ export function createFontResolver(fontParser, unicodeFontResolverClient) {
   function doLoadFont(url, callback) {
     const onError = err => {
       console.error(`Failure loading font ${url}`, err)
+      callback({ supportsCodePoint: () => null })
     }
     try {
       const request = new XMLHttpRequest()


### PR DESCRIPTION
When a font loading fails, invoke the callback to return from `doLoadFont`. The object returned will have a function `supportsCodePoint` to indicate there's no glyphs. With this, we'll skip its usage and render using the default font.